### PR TITLE
Use GitHub to mark this repository as archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # prosemirror-schema-table
 
-**NOTE:** This module is deprecated, and doesn't work in current versions of ProseMirror. Consider moving to the [new table module](https://github.com/prosemirror/prosemirror-tables/).
+**NOTE:** This module is archived, and doesn't work in current versions of ProseMirror. Consider moving to the [new table module](https://github.com/prosemirror/prosemirror-tables/).
 
 [ [**WEBSITE**](http://prosemirror.net) | [**ISSUES**](https://github.com/prosemirror/prosemirror/issues) | [**FORUM**](https://discuss.prosemirror.net) | [**GITTER**](https://gitter.im/ProseMirror/prosemirror) | [**CHANGELOG**](https://github.com/ProseMirror/prosemirror/blob/master/CHANGELOG.md) ]
 


### PR DESCRIPTION
Please reject this PR, then use GitHub feature to mark this repository as archived. So it does not appear too easily in search results, and it very clearly conveys the state of this package:

https://github.com/ProseMirror/prosemirror-schema-table/settings#danger-zone

![image](https://user-images.githubusercontent.com/72603/195567909-3bb3b2a1-1cc0-45b8-9d04-23a6adbb0aca.png)
